### PR TITLE
Add support for bindep.txt

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see http://docs.openstack.org/infra/bindep/ for additional information.
+
+gcc-c++ [test platform:rpm]


### PR DESCRIPTION
We use bindep.txt files in zuul CI, to help identify which OS
dependencies are required for the job.  In this case, we add python26
support for fedora.

As we add more zuul jobs, this fix will expand to include more things.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/54
Signed-off-by: Paul Belanger <pabelanger@redhat.com>