### PR TITLE
Remove ansible-test-sanity job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,8 +1,6 @@
 - project:
     check:
       jobs:
-        - ansible-test-sanity:
-            voting: False
         - ansible-network-tox-py27:
             required-projects:
               - name: github.com/ansible-network/network-engine


### PR DESCRIPTION
This was non-voting and currently takes up testing resources each PR. As
we plan to move to molecule, we can consider running ansible-test when
it grows support.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>