### PR TITLE
Add python3 dependencies to bindep.txt

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,17 +3,17 @@
       jobs:
         - ansible-test-sanity:
             voting: False
-        - tox-py27:
+        - ansible-network-tox-py27:
             required-projects:
               - name: github.com/ansible-network/network-engine
-        - tox-py36:
+        - ansible-network-tox-py36:
             required-projects:
               - name: github.com/ansible-network/network-engine
     gate:
       jobs:
-        - tox-py27:
+        - ansible-network-tox-py27:
             required-projects:
               - name: github.com/ansible-network/network-engine
-        - tox-py36:
+        - ansible-network-tox-py36:
             required-projects:
               - name: github.com/ansible-network/network-engine

--- a/bindep.txt
+++ b/bindep.txt
@@ -2,3 +2,6 @@
 # see http://docs.openstack.org/infra/bindep/ for additional information.
 
 gcc-c++ [test platform:rpm]
+python3-devel [test !platform:centos-7 platform:rpm]
+python3 [test !platform:centos-7 platform:rpm]
+python36 [test !platform:centos-7 !platform:fedora-28]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+ara
 flake8
 pyang
 ncclient

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
 setenv =
-  ANSIBLE_CONFIG = tests/ansible.cfg
+  ANSIBLE_CALLBACK_PLUGINS = {envsitepackagesdir}/ara/plugins/callbacks
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
This should fix our tox jobs for fedora-29 now.

Depends-On: https://github.com/ansible-network/ansible-zuul-jobs/pull/105
Signed-off-by: Paul Belanger <pabelanger@redhat.com>