### PR TITLE
Fix failure of json2xml lookup plugin when using multiple hosts

### DIFF
--- a/lookup_plugins/yang_json2xml.py
+++ b/lookup_plugins/yang_json2xml.py
@@ -132,7 +132,7 @@ class LookupModule(LookupBase):
                 abs_search_path = path
             else:
                 abs_search_path += ':' + path
-            if path is not '' and not os.path.isdir(path):
+            if path != '' and not os.path.isdir(path):
                 raise AnsibleError('%s is invalid directory path' % path)
 
         search_path = abs_search_path

--- a/lookup_plugins/yang_json2xml.py
+++ b/lookup_plugins/yang_json2xml.py
@@ -157,11 +157,14 @@ class LookupModule(LookupBase):
         saved_stderr = sys.stderr
         sys.stdout = sys.stderr = StringIO()
 
+        plugin_instance = str(uuid.uuid4())
+
         plugindir = unfrackpath(JSON2XML_DIR_PATH)
         makedirs_safe(plugindir)
+        makedirs_safe(os.path.join(plugindir, plugin_instance))
 
-        jtox_file_path = os.path.join(JSON2XML_DIR_PATH, '%s.%s' % (str(uuid.uuid4()), 'jtox'))
-        xml_file_path = os.path.join(JSON2XML_DIR_PATH, '%s.%s' % (str(uuid.uuid4()), 'xml'))
+        jtox_file_path = os.path.join(JSON2XML_DIR_PATH, plugin_instance, '%s.%s' % (str(uuid.uuid4()), 'jtox'))
+        xml_file_path = os.path.join(JSON2XML_DIR_PATH, plugin_instance, '%s.%s' % (str(uuid.uuid4()), 'xml'))
         jtox_file_path = os.path.realpath(os.path.expanduser(jtox_file_path))
         xml_file_path = os.path.realpath(os.path.expanduser(xml_file_path))
 
@@ -178,13 +181,15 @@ class LookupModule(LookupBase):
         except SystemExit:
             pass
         except Exception as e:
-            shutil.rmtree(os.path.realpath(os.path.expanduser(JSON2XML_DIR_PATH)), ignore_errors=True)
+            temp_dir = os.path.join(JSON2XML_DIR_PATH, plugin_instance)
+            shutil.rmtree(os.path.realpath(os.path.expanduser(temp_dir)), ignore_errors=True)
             raise AnsibleError('Error while generating intermediate (jtox) file: %s' % e)
         finally:
             err = sys.stderr.getvalue()
             if err and 'error' in err.lower():
                 if not keep_tmp_files:
-                    shutil.rmtree(os.path.realpath(os.path.expanduser(JSON2XML_DIR_PATH)), ignore_errors=True)
+                    temp_dir = os.path.join(JSON2XML_DIR_PATH, plugin_instance)
+                    shutil.rmtree(os.path.realpath(os.path.expanduser(temp_dir)), ignore_errors=True)
                 raise AnsibleError('Error while generating intermediate (jtox) file: %s' % err)
 
         json2xml_exec_path = find_file_in_path('json2xml')
@@ -204,7 +209,8 @@ class LookupModule(LookupBase):
             err = sys.stderr.getvalue()
             if err and 'error' in err.lower():
                 if not keep_tmp_files:
-                    shutil.rmtree(os.path.realpath(os.path.expanduser(JSON2XML_DIR_PATH)), ignore_errors=True)
+                    temp_dir = os.path.join(JSON2XML_DIR_PATH, plugin_instance)
+                    shutil.rmtree(os.path.realpath(os.path.expanduser(temp_dir)), ignore_errors=True)
                 raise AnsibleError('Error while translating to xml: %s' % err)
             sys.argv = saved_arg
             sys.stdout = saved_stdout
@@ -217,7 +223,8 @@ class LookupModule(LookupBase):
             raise AnsibleError('Error while reading xml document: %s' % e)
         finally:
             if not keep_tmp_files:
-                shutil.rmtree(os.path.realpath(os.path.expanduser(JSON2XML_DIR_PATH)), ignore_errors=True)
+                temp_dir = os.path.join(JSON2XML_DIR_PATH, plugin_instance)
+                shutil.rmtree(os.path.realpath(os.path.expanduser(temp_dir)), ignore_errors=True)
         res.append(etree.tostring(root))
 
         return res

--- a/lookup_plugins/yang_spec.py
+++ b/lookup_plugins/yang_spec.py
@@ -230,7 +230,7 @@ class LookupModule(LookupBase):
 
         for path in search_path.split(':'):
             path = os.path.realpath(os.path.expanduser(path))
-            if path is not '' and not os.path.isdir(path):
+            if path != '' and not os.path.isdir(path):
                 raise AnsibleError('%s is invalid directory path' % path)
 
         keep_tmp_files = kwargs.pop('keep_tmp_files', False)

--- a/lookup_plugins/yang_xml2json.py
+++ b/lookup_plugins/yang_xml2json.py
@@ -128,7 +128,7 @@ class LookupModule(LookupBase):
                 abs_search_path = path
             else:
                 abs_search_path += ':' + path
-            if path is not '' and not os.path.isdir(path):
+            if path != '' and not os.path.isdir(path):
                 raise AnsibleError('%s is invalid directory path' % path)
 
         search_path = abs_search_path

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,2 @@
 localhost
+localhost-1 ansible_host=localhost

--- a/tests/yang_json2xml/test.yml
+++ b/tests/yang_json2xml/test.yml
@@ -1,4 +1,4 @@
-- hosts: localhost
+- hosts: all
   connection: local
   roles:
     - yang_json2xml


### PR DESCRIPTION
The json2xml lookup plugin stores temporary files (like the jtox file required by pyang to generate the XML) in ~/.ansible/tmp/json2xml.

When the plugin completes this directory is deleted to clean up after itself.

When running on multiple hosts this plugin is run in parallel and as a result the first time the plugin completes it will delete the temporary files required by the other instances before they have completed execution.

As a result we show store the temporary files for each instance of the plugin in a different directory and only clean this directory at the end of execution.